### PR TITLE
Enhancements in Dataset Inclusion Flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # model_seg_generalist
 
 ## How to train
-This model is trained on 5 datasets. The preprocessing script expects the following 5 datasets, already in nnunet format:
+This model can be trained on multiple datasets. The preprocessing script expects the datasets, already in nnunet format, to be located in a specific directory (the directory containing `nnUNet_raw`, `nnUNet_preprocessed`, `nnUNet_results`). The indices of the datasets to be used for training must be passed as arguments to the script.
+
+The datasets could be any of the following:
 
 - TEM dataset
 - SEM dataset
@@ -9,10 +11,19 @@ This model is trained on 5 datasets. The preprocessing script expects the follow
 - BF dataset (wakehealth, human)
 - BF dataset (VCU, rabbit)
 
-First, run the aggregation script:
+First, run the aggregation script with the required arguments. The script expects the following arguments:
+
+- `--nnunet_dir`: The path to the directory containing the datasets.
+- `--dataset_ids`: A list of indices of the datasets to be used for training. If no indices are provided, all datasets in the directory will be used.
+- `--name`: (Optional) The name you want to assign to the aggregated dataset. Defaults to 'Dataset444_AGG'.
+- `--description`: (Optional) A description for the aggregated dataset. Defaults to 'Aggregated dataset from all source domains'.
+- `--k`: (Optional) The number of folds for cross-validation. Defaults to 5.
+
+Here is an example command to run the script:
 ```
-python nnunet_scripts/aggregate_data.py -i path_to_directory_containing_dsets -o .
+python nnunet_scripts/aggregate_data.py --nnunet_dir path_to_directory_containing_dsets --dataset_ids <dataset_index_1> <dataset_index_2> ... <dataset_index_n> --name MyAggregatedDataset --description "Aggregated dataset for my experiment" --k 5
 ```
+Replace `<dataset_index_1> <dataset_index_2> ... <dataset_index_n>` with the indices of the datasets you want to use for training.
 
 This will create a new nnunet dataset. We can then run the initial setup, 
 move the manual split in the preprocessed folder and start training:

--- a/nnunet_scripts/aggregate_data.py
+++ b/nnunet_scripts/aggregate_data.py
@@ -1,20 +1,74 @@
 """
 This script aggregates data by processing images from all datasets and 
 copying them into a new single nnunet formatted dataset. It also creates a 
-3-fold cross-validation scheme manually to ensure the splits contain data from 
+k-fold cross-validation scheme manually to ensure the splits contain data from 
 all domains.
 Author: Armand Collin
 """
 
 import argparse
 import json
-from pathlib import Path
-from sklearn.model_selection import KFold
 import shutil
+from pathlib import Path
+from typing import List, Literal
 
-def create_splits(dataset, n_splits=3):
-    '''Creates n_splits train-val splits for the given dataset. Please 
-    note that the splits might not have exactly the same length.'''
+from sklearn.model_selection import KFold
+
+
+def parse_args():
+    """
+    Parse command line arguments.
+
+    Returns:
+        argparse.ArgumentParser: Argument parser.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--nnunet_dir",
+        help="Path to nnunet directory, where the existing datasets are stored and where the new dataset will be created.",
+    )
+    parser.add_argument(
+        "--dataset_ids",
+        nargs="*",
+        default=None,
+        help="List of dataset indices to be combined. Default: all datasets",
+    )
+    parser.add_argument(
+        "--name",
+        default="Dataset444_AGG",
+        help="Name of the aggregated dataset. Default: 'Dataset444_AGG'",
+    )
+    parser.add_argument(
+        "--description",
+        default="Aggregated dataset from all source domains",
+        help="Description of the aggregated dataset. Default: 'Aggregated dataset from all source domains'",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=5,
+        help="Number of folds for cross-validation. Default: 5",
+    )
+    return parser.parse_args()
+
+
+def create_splits(dataset: List[str], n_splits: int = 5):
+    """
+    Creates n_splits train-val splits for the given dataset. Please
+    note that the splits might not have exactly the same length.
+
+    Parameters
+    ----------
+    dataset : List[str]
+        List of image names in the dataset.
+    n_splits : int, optional
+        Number of splits to create, by default 5
+
+    Returns
+    -------
+    splits : List[Tuple[List[str], List[str]]]
+        List of train-val splits for each fold.
+    """
     kf = KFold(n_splits=n_splits)
     splits = []
     for train_index, val_index in kf.split(dataset):
@@ -23,116 +77,161 @@ def create_splits(dataset, n_splits=3):
         splits.append((train, val))
     return splits
 
-def map_images(datasets, image_type, current_index):
+
+def map_images(
+    datasets: List[str], image_type: Literal["imagesTr", "imagesTs"], current_index: int
+):
+    """
+    Creates a mapping between the original filenames and the new filenames
+
+    Parameters
+    ----------
+    datasets : List[str]
+        List of datasets to aggregate.
+    image_type : Literal["imagesTr", "imagesTs"]
+        Type of images to aggregate. Either training or test images.
+    current_index : int
+        Current index of the image to aggregate.
+    """
     fname_mapping = {}
     for dataset in datasets:
-        images = [im for im in (dataset / image_type).glob('*.png')]
+        images = [im for im in (dataset / image_type).glob("*.png")]
         for image in images:
-            new_fname = f'AGG_{current_index:03d}_0000.png'
+            new_fname = f"AGG_{current_index:03d}_0000.png"
             old_fname = str(image.name)
             fname_mapping[old_fname] = new_fname
             current_index += 1
     return fname_mapping, current_index
 
+
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input", help="Where the datasets are located")
-    parser.add_argument("-o", "--output", help="Where to save the aggregated dataset")
-    args = parser.parse_args()
+    # Parse command line arguments
+    args = parse_args()
 
-    input_dir = Path(args.input)
-    output_dir = Path(args.output)
+    # Number of folds for cross-validation
+    k = args.k
 
-    datasets = [x for x in input_dir.glob('Dataset*')]
+    # Directories for the aggregated dataset
+    nnunet_dir = Path(args.nnunet_dir)
+    nnunet_raw_dir = nnunet_dir / "nnUNet_raw"
+
+    raw_dataset_path = nnunet_dir / "nnUNet_raw" / args.name
+    raw_dataset_path.mkdir(exist_ok=False)
+
+    preprocessed_dataset_path = nnunet_dir / "nnUNet_preprocessed" / args.name
+    preprocessed_dataset_path.mkdir(exist_ok=False)
+
+    # Convert dataset_ids to string of k characters each by padding zeros at the front
+    if args.dataset_ids is not None:
+        datasets = [f"Dataset{int(id):03d}" for id in args.dataset_ids]
+
+    if args.dataset_ids is not None:
+        # filter datasets
+        datasets = [
+            x for x in nnunet_raw_dir.glob("Dataset*") if x.name[:10] in datasets
+        ]
+    else:
+        datasets = [x for x in nnunet_raw_dir.glob("Dataset*")]
+
+    # create a dictionary with all the paths of each dataset
     data_dict = {}
     # Iterate over all datasets
     for dataset in datasets:
-        images_tr = [im for im in (dataset / 'imagesTr').glob('*.png')]
-        images_ts = [im for im in (dataset / 'imagesTs').glob('*.png')]
+        images_tr = [im for im in (dataset / "imagesTr").glob("*.png")]
+        images_ts = [im for im in (dataset / "imagesTs").glob("*.png")]
         data_dict[str(dataset)] = {
-            'imagesTr': images_tr,
-            'imagesTs': images_ts,
-            'numTraining': len(images_tr),
-            'numTest': len(images_ts)
+            "imagesTr": images_tr,
+            "imagesTs": images_ts,
+            "numTraining": len(images_tr),
+            "numTest": len(images_ts),
         }
 
+    # Create a mapping between the original filenames and the new filenames
     new_index = 0
-    fname_mapping_tr, new_index = map_images(datasets, 'imagesTr', new_index)
-    fname_mapping_ts, new_index = map_images(datasets, 'imagesTs', new_index)
+    fname_mapping_tr, new_index = map_images(datasets, "imagesTr", new_index)
+    fname_mapping_ts, new_index = map_images(datasets, "imagesTs", new_index)
     fname_mapping = {
-        'images_tr': fname_mapping_tr,
-        'images_ts': fname_mapping_ts,
-        'numTraining': len(fname_mapping_tr),
-        'numTest': len(fname_mapping_ts)
+        "images_tr": fname_mapping_tr,
+        "images_ts": fname_mapping_ts,
+        "numTraining": len(fname_mapping_tr),
+        "numTest": len(fname_mapping_ts),
     }
 
     # save mapping
-    with open(output_dir / 'fname_mapping.json', 'w') as f:
+    with open(raw_dataset_path / "fname_mapping.json", "w") as f:
         json.dump(fname_mapping, f)
 
-    # create the 3-fold train-val splits for every dataset:
+    # create the k-fold train-val splits for every dataset:
     train_val_splits = {str(dataset): [] for dataset in datasets}
     for dataset_name in datasets:
         dataset = str(dataset_name)
-        images_tr = data_dict[dataset]['imagesTr']
+        images_tr = data_dict[dataset]["imagesTr"]
         images_tr = [str(i.name) for i in images_tr]
-        train_val_splits[dataset] = create_splits(images_tr, n_splits=3)
+        train_val_splits[dataset] = create_splits(images_tr, n_splits=k)
 
     # convert splits from source domains to target domain
-    target_splits = [{'train': [], 'val': []} for i in range(3)]
-    for fold in range(3):
-        for dataset in datasets:
-            current_split = train_val_splits[str(dataset)][fold]
+    target_splits = [{"train": [], "val": []} for i in range(k)]
+    for fold in range(k):
+        for i, dataset in enumerate(datasets):
+            # when combining the splits together, we want to make sure that there is approximately the same number of images in each validation set
+            if i % 2 == 0:
+                current_split = train_val_splits[str(dataset)][fold]
+            else:
+                current_split = train_val_splits[str(dataset)][k - fold - 1]
             train, val = current_split
-            target_train = [fname_mapping['images_tr'][im].replace('_0000.png', '') for im in train]
-            target_val = [fname_mapping['images_tr'][im].replace('_0000.png', '') for im in val]
-            target_splits[fold]['train'].extend(target_train)
-            target_splits[fold]['val'].extend(target_val)
-    # save splits
-    with open(output_dir / 'final_splits.json', 'w') as f:
+            target_train = [
+                fname_mapping["images_tr"][im].replace("_0000.png", "") for im in train
+            ]
+            target_val = [
+                fname_mapping["images_tr"][im].replace("_0000.png", "") for im in val
+            ]
+            target_splits[fold]["train"].extend(target_train)
+            target_splits[fold]["val"].extend(target_val)
+
+    # save splits to file as described in nnunet documentation (https://github.com/MIC-DKFZ/nnUNet/blob/master/documentation/manual_data_splits.md)
+    with open(preprocessed_dataset_path / "splits_final.json", "w") as f:
         json.dump(target_splits, f)
 
     # finally, copy files into the new aggregated dataset
-    output_data_path = output_dir / 'nnUNet_raw' / 'Dataset444_AGG'
-    output_data_path.mkdir(exist_ok=False)
-    (output_data_path / 'imagesTr').mkdir(exist_ok=False)
-    (output_data_path / 'labelsTr').mkdir(exist_ok=False)
-    (output_data_path / 'imagesTs').mkdir(exist_ok=False)
+    (raw_dataset_path / "imagesTr").mkdir(exist_ok=False)
+    (raw_dataset_path / "labelsTr").mkdir(exist_ok=False)
+    (raw_dataset_path / "imagesTs").mkdir(exist_ok=False)
     for dataset in datasets:
         dataset_name = str(dataset)
-        images_tr = data_dict[dataset_name]['imagesTr']
-        images_ts = data_dict[dataset_name]['imagesTs']
+        images_tr = data_dict[dataset_name]["imagesTr"]
+        images_ts = data_dict[dataset_name]["imagesTs"]
+
+        # copy images and labels in the training sets
         for image in images_tr:
-            new_fname = fname_mapping['images_tr'][image.name]
-            image_path_target = output_data_path / 'imagesTr' / new_fname
+            # copy the image to the new dataset
+            new_fname = fname_mapping["images_tr"][image.name]
+            image_path_target = raw_dataset_path / "imagesTr" / new_fname
             shutil.copy(image, image_path_target)
+
             # also copy the corresponding label
-            label_fname = image.name.replace('_0000.png', '.png')
-            label = image.parent.parent / 'labelsTr' / label_fname
-            new_label_fname = new_fname.replace('_0000.png', '.png')
-            label_path_target = output_data_path / 'labelsTr' / new_label_fname
+            label_fname = image.name.replace("_0000.png", ".png")
+            label = image.parent.parent / "labelsTr" / label_fname
+            new_label_fname = new_fname.replace("_0000.png", ".png")
+            label_path_target = raw_dataset_path / "labelsTr" / new_label_fname
             shutil.copy(label, label_path_target)
+
+        # copy images in the test sets
         for image in images_ts:
-            new_fname = fname_mapping['images_ts'][image.name]
-            image_path = output_data_path / 'imagesTs' / new_fname
+            new_fname = fname_mapping["images_ts"][image.name]
+            image_path = raw_dataset_path / "imagesTs" / new_fname
             shutil.copy(image, image_path)
+
     # create dataset.json file
     dataset_json = {
-        'name': 'Dataset444_AGG',
-        'description': 'Aggregated dataset from all source domains',
-        "labels": {
-            "background": 0,
-            "myelin": 1,
-            "axon": 2
-        },
-        "channel_names": {
-            "0": "rescale_to_0_1"
-        },
-        "numTraining": fname_mapping['numTraining'],
-        "numTest": fname_mapping['numTest'],
-        "file_ending": ".png"
+        "name": args.name,
+        "description": args.description,
+        "labels": {"background": 0, "myelin": 1, "axon": 2},
+        "channel_names": {"0": "rescale_to_0_1"},
+        "numTraining": fname_mapping["numTraining"],
+        "numTest": fname_mapping["numTest"],
+        "file_ending": ".png",
     }
-    with open(output_data_path / 'dataset.json', 'w') as f:
+    with open(raw_dataset_path / "dataset.json", "w") as f:
         json.dump(dataset_json, f)
 
 


### PR DESCRIPTION
# Pull Request: Enhancements in Dataset Inclusion Flexibility

## Overview
This pull request introduces key enhancements in the flexibility of dataset inclusion. It significantly simplifies the process of dataset aggregation and addresses two pivotal issues identified in our GitHub repository.

## Enhancements
- Updated `README.md` to accurately reflect the new changes and guide users through the updated processes.
- Refactored `aggregate_data.py` script to correct the filename for `splits_final.json` and enable more flexibility. Now, users can specify which datasets to include in the aggregated dataset, and customize the name, description, and number of stratification folds in `final_splits.json`.

## Addressed GitHub Issues
- **[Issue #5](https://github.com/axondeepseg/model_seg_generalist/issues/5)**: Resolved the filename inconsistency with `splits_final.json`. The script autonomously places the file in the designated directory, specifically `nnUNet_preprocessed/DATASETXXX_NAME`, eliminating the need for a separate command to specify the file's location.
- **[Issue #6](https://github.com/axondeepseg/model_seg_generalist/issues/6)**: The script modifications facilitate an ablation study on data aggregation. It allows for a comparative analysis between models trained on aggregated Bright Field (BF) datasets and dedicated BF models.

## Conclusion
These changes enhance the project's functionality and user experience, addressing community-reported issues and improving data handling capabilities. Feedback and further contributions are welcome to refine these features.
