### PR TITLE
OOD Experiment Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,58 @@ For instance, to run the script with specific datasets, use the command below:
 source ./nnunet_scripts/inference_and_evaluation.sh ${RESULTS_DIR}/nnUNet_results Dataset002_SEM Dataset003_TEM Dataset004_BF_RAT Dataset005_wakehealth Dataset006_BF_VCU Dataset444_AGG
 ```
 
+To replicate out of distribution experiments (OOD), you can use the following script:
 
+```bash
+source ./nnunet_scripts/ood_results.sh <PATH_TO_OOD_DATASET> ${RESULTS_DIR}/nnUNet_results <DATASET_1> <DATASET_2> <DATASET_3> ... <DATASET_N>
+```
+
+Ensure the OOD dataset adheres to the following structure prior to executing the script:
+
+```
+├── <MODALITY 1>
+│   ├── some species
+│       ├── image_0000.png
+│       └── (optional) labels
+│            └── image.png
+|   ...
+│   └── another species
+│       ├── image_0000.png
+│       └── (optional) labels
+│            └── image.png
+└── <MODALITY N>
+    ...
+```
+
+For instance:
+
+```   
+├── BF
+│   └── cat
+│       └── CAT_0000.png
+├── SEM
+│   ├── dog
+│   │   └── DOG_0000.png
+│   └── human
+│       ├── AGG_203_0000.png
+│       └── labels
+│            └── AGG_203.png
+└── TEM
+    └── macaque
+        ├── labels
+              ├── MACAQUE_000_0000.png
+              ├── MACAQUE_001_0000.png
+              ├── MACAQUE_002_0000.png
+              ├── MACAQUE_003_0000.png
+              ├── MACAQUE_004_0000.png
+             ...
+        ├── MACAQUE_000_0000.png
+        ├── MACAQUE_001_0000.png
+        ├── MACAQUE_002_0000.png
+        ├── MACAQUE_003_0000.png
+        ├── MACAQUE_004_0000.png
+       ...
+```
 ## Authors
 
 - Armand Collin

--- a/nnunet_scripts/ood_results.sh
+++ b/nnunet_scripts/ood_results.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+OOD_PATH=$1
+NNUNET_PATH=$2
+
+shift 2
+models=("$@")
+
+# print the structure of the OOD dataset
+echo -e "\n############## Printing the structure of the OOD dataset. ##############\n"
+tree $OOD_PATH
+
+# Get all second level directories
+second_level_dirs=()
+for dir in "$OOD_PATH"/*; do
+    if [ -d "$dir" ]; then
+        for sub_dir in "$dir"/*; do
+            if [ -d "$sub_dir" ]; then
+                second_level_dirs+=("$sub_dir")
+            fi
+        done
+    fi
+done
+
+# Convert all images to grayscale (Expected by nnunet models)
+echo -e "\n############## Converting all images to grayscale. ##############\n"
+for dir in ${second_level_dirs[@]}; do
+    python utils/make_gray_scale.py $dir
+done
+
+echo -e "\n############## Running OOD inference and evaluation. ##############\n"
+for model in ${models[@]}; do
+    for dataset in ${second_level_dirs[@]}; do
+        echo -e "\n\nRun inference with ${NNUNET_PATH}/nnUNet_results/${model} model on $dataset\n\n"
+        model_name=${model#Dataset???_}
+
+        python nnunet_scripts/run_inference.py  --path-dataset $dataset \
+                                                --path-out ${dataset}/segmentations/ensemble/${model_name}_model_best_checkpoints_inference \
+                                                --path-model ${NNUNET_PATH}/nnUNet_results/${model}/nnUNetTrainer__nnUNetPlans__2d/ \
+                                                --use-gpu \
+                                                --use-best-checkpoint
+
+        if [ -d "$dataset/labels" ]; then
+            python nnunet_scripts/run_evaluation.py --pred_path ${dataset}/segmentations/ensemble/${model_name}_model_best_checkpoints_inference \
+                                                    --gt_path ${dataset}/labels \
+                                                    --output_fname ${dataset}/segmentations/ensemble/scores/${model_name}_model_best_checkpoints_scores \
+                                                    --pred_suffix _0000
+        else
+            echo "Skipping evaluation of $dataset as it does not contain a 'labels' subdirectory."
+        fi
+                                    
+
+        python utils/make_segmentations_visible.py  ${dataset}/segmentations/ensemble/${model_name}_model_best_checkpoints_inference \
+                                                    ${dataset}/segmentations/ensemble/${model_name}_model_best_checkpoints_inference
+
+        # Run inference and evaluation for each fold
+        for fold in {0..4}; do
+            echo -e "\nProcessing fold $fold\n"
+            python nnunet_scripts/run_inference.py  --path-dataset $dataset \
+                                                    --path-out ${dataset}/segmentations/fold_${fold}/${model_name}_model_best_checkpoints_inference \
+                                                    --path-model ${NNUNET_PATH}/nnUNet_results/${model}/nnUNetTrainer__nnUNetPlans__2d/ \
+                                                    --use-gpu \
+                                                    --folds $fold \
+                                                    --use-best-checkpoint
+
+            if [ -d "$dataset/labels" ]; then
+                python nnunet_scripts/run_evaluation.py --pred_path ${dataset}/segmentations/fold_${fold}/${model_name}_model_best_checkpoints_inference \
+                                                        --gt_path ${dataset}/labels \
+                                                        --output_fname ${dataset}/segmentations/fold_${fold}/scores/${model_name}_model_best_checkpoints_scores \
+                                                        --pred_suffix _0000
+            fi
+
+            python utils/make_segmentations_visible.py  ${dataset}/segmentations/fold_${fold}/${model_name}_model_best_checkpoints_inference \
+                                                        ${dataset}/segmentations/fold_${fold}/${model_name}_model_best_checkpoints_inference
+        done
+    done
+done


### PR DESCRIPTION
## OOD Experiment Support

This PR adds support for running experiments to replicate Out of Distribution (OOD) experiments using our nnU-Net framework. We've added a new script, `ood_results.sh`, and provided detailed guidelines for structuring the OOD dataset to ensure successful experiment replication.

### Instructions for OOD Experiments

To replicate OOD experiments, use the following script:

```bash
source ./nnunet_scripts/ood_results.sh <PATH_TO_OOD_DATASET> ${RESULTS_DIR}/nnUNet_results <DATASET_1> <DATASET_2> <DATASET_3> ... <DATASET_N>
```
Users should format the OOD dataset as detailed in the `README.md`.