### PR TITLE
Remove unnecessary dataset_name argument from setup script

### DIFF
--- a/nnunet_scripts/setup_nnunet.sh
+++ b/nnunet_scripts/setup_nnunet.sh
@@ -8,7 +8,6 @@ fi
 
 RESULTS_DIR=$(realpath $1)
 dataset_id=${2:-444}
-dataset_name=${3:-"AGG"}
 
 echo "-------------------------------------------------------"
 echo "Converting dataset to nnUNetv2 format"


### PR DESCRIPTION
**Minor Fix**: Removed unnecessary argument `dataset_name` in the setup script. We only need the `dataset_id` to call the `nnUNetv2_plan_and_preprocess` function by nnUNet.
